### PR TITLE
Add the method itself to the context

### DIFF
--- a/src/addAspect.ts
+++ b/src/addAspect.ts
@@ -23,9 +23,9 @@ export function addAspect(target: any, methodName: string, advice: Advice, aspec
             const tsAspectProp = getTsAspectProp(target);
             if (tsAspectProp) {
                 if (types.isAsyncFunction(originalMethod)) {
-                    return asyncProxyFunc(target, tsAspectProp[methodName], ...args);
+                    return asyncProxyFunc(target, methodName, tsAspectProp[methodName], ...args);
                 } else {
-                    return proxyFunc(target, tsAspectProp[methodName], ...args);
+                    return proxyFunc(target, methodName, tsAspectProp[methodName], ...args);
                 }
             }
             return originalMethod(...args);

--- a/src/aspect.interface.ts
+++ b/src/aspect.interface.ts
@@ -4,7 +4,7 @@ export interface Aspect {
 
 export type AspectContext = {
     target: any;
-    method: any;
+    methodName: string;
     functionParams: any[];
     returnValue: any;
     error: any;

--- a/src/aspect.interface.ts
+++ b/src/aspect.interface.ts
@@ -4,6 +4,7 @@ export interface Aspect {
 
 export type AspectContext = {
     target: any;
+    method: any;
     functionParams: any[];
     returnValue: any;
     error: any;

--- a/src/decorator/UseAspect.ts
+++ b/src/decorator/UseAspect.ts
@@ -26,9 +26,9 @@ export function UseAspect(advice: Advice, aspect: Aspect | (new () => Aspect)): 
                 const tsAspectProp = getTsAspectProp(target);
                 if (tsAspectProp) {
                     if (types.isAsyncFunction(originalMethod)) {
-                        return asyncProxyFunc(this, tsAspectProp[propertyKeyString], ...args);
+                        return asyncProxyFunc(this, propertyKeyString, tsAspectProp[propertyKeyString], ...args);
                     } else {
-                        return proxyFunc(this, tsAspectProp[propertyKeyString], ...args);
+                        return proxyFunc(this, propertyKeyString, tsAspectProp[propertyKeyString], ...args);
                     }
                 }
                 return originalMethod(...args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,12 @@ import { addAspectToPointcut } from './addAspectToPointcut';
 import { resetAllAspects } from './resetAllAspects';
 import { UseAspect } from './decorator/UseAspect';
 
-export { Advice, Aspect, AspectContext, addAspect, addAspectToPointcut, resetAllAspects, UseAspect };
+export {
+    Advice,
+    Aspect,
+    AspectContext,
+    addAspect,
+    addAspectToPointcut,
+    resetAllAspects,
+    UseAspect,
+};

--- a/src/proxyFunc.ts
+++ b/src/proxyFunc.ts
@@ -10,6 +10,7 @@ export async function asyncProxyFunc(
     const { originalMethod, adviceAspectMap } = methodContainer;
     const aspectCtx: AspectContext = {
         target: target,
+        method: originalMethod,
         functionParams: args,
         returnValue: null,
         error: null,
@@ -45,6 +46,7 @@ export function proxyFunc(target: any, methodContainer: MethodContainer, ...args
     const { originalMethod, adviceAspectMap } = methodContainer;
     const aspectCtx: AspectContext = {
         target: target,
+        method: originalMethod,
         functionParams: args,
         returnValue: null,
         error: null,

--- a/src/proxyFunc.ts
+++ b/src/proxyFunc.ts
@@ -4,13 +4,14 @@ import { AdviceAspectMap, MethodContainer } from './TsAspectContainer';
 
 export async function asyncProxyFunc(
     target: any,
+    methodName: string,
     methodContainer: MethodContainer,
     ...args: any
 ): Promise<any> {
     const { originalMethod, adviceAspectMap } = methodContainer;
     const aspectCtx: AspectContext = {
         target: target,
-        method: originalMethod,
+        methodName: methodName,
         functionParams: args,
         returnValue: null,
         error: null,
@@ -42,11 +43,11 @@ export async function asyncProxyFunc(
     return aspectCtx.returnValue;
 }
 
-export function proxyFunc(target: any, methodContainer: MethodContainer, ...args: any): any {
+export function proxyFunc(target: any, methodName: string, methodContainer: MethodContainer, ...args: any): any {
     const { originalMethod, adviceAspectMap } = methodContainer;
     const aspectCtx: AspectContext = {
         target: target,
-        method: originalMethod,
+        methodName: methodName,
         functionParams: args,
         returnValue: null,
         error: null,

--- a/test/addAspect.test.ts
+++ b/test/addAspect.test.ts
@@ -65,6 +65,7 @@ describe('addAspect', () => {
 
             const expectedCtx: AspectContext = {
                 target: calculator,
+                method: calculator.add,
                 functionParams: [1, 2],
                 returnValue: 3,
                 error: null,
@@ -82,6 +83,7 @@ describe('addAspect', () => {
 
         const expectedCtx: AspectContext = {
             target: calculator,
+            method: calculator.divide,
             functionParams: [1, 0],
             returnValue: null,
             error: new Error('Division by zero!'),
@@ -102,6 +104,7 @@ describe('addAspect', () => {
 
         const expectedCtx: AspectContext = {
             target: calculator,
+            method: calculator.add,
             functionParams: [1, 2],
             returnValue: 3,
             error: null,

--- a/test/addAspect.test.ts
+++ b/test/addAspect.test.ts
@@ -65,7 +65,7 @@ describe('addAspect', () => {
 
             const expectedCtx: AspectContext = {
                 target: calculator,
-                method: calculator.add,
+                methodName: 'add',
                 functionParams: [1, 2],
                 returnValue: 3,
                 error: null,
@@ -83,7 +83,7 @@ describe('addAspect', () => {
 
         const expectedCtx: AspectContext = {
             target: calculator,
-            method: calculator.divide,
+            methodName: 'divide',
             functionParams: [1, 0],
             returnValue: null,
             error: new Error('Division by zero!'),
@@ -104,7 +104,7 @@ describe('addAspect', () => {
 
         const expectedCtx: AspectContext = {
             target: calculator,
-            method: calculator.add,
+            methodName: 'add',
             functionParams: [1, 2],
             returnValue: 3,
             error: null,

--- a/test/decorator/UseAspect.test.ts
+++ b/test/decorator/UseAspect.test.ts
@@ -42,7 +42,17 @@ describe('UseAspect', () => {
         sample.getSampleId();
 
         expect(beforeAspect.execute).toHaveBeenCalledTimes(1);
+
+        const expectedCtx: AspectContext = {
+            target: sample,
+            methodName: 'getSampleId',
+            functionParams: [],
+            returnValue: 1,
+            error: null,
+        };
+        expect(beforeAspect.execute).toHaveBeenCalledWith(expectedCtx);
     });
+
 
     it('should instantiate a new object of the aspect class passed as parameter', () => {
         let executeHasBeenCalled = false;

--- a/test/decorator/UseAspect.test.ts
+++ b/test/decorator/UseAspect.test.ts
@@ -53,7 +53,6 @@ describe('UseAspect', () => {
         expect(beforeAspect.execute).toHaveBeenCalledWith(expectedCtx);
     });
 
-
     it('should instantiate a new object of the aspect class passed as parameter', () => {
         let executeHasBeenCalled = false;
         class SomeAspect implements Aspect {


### PR DESCRIPTION
Thanks for this useful project!

Is there a way to retrieve which method was called? In the README example, if I wanted to log which calculator method was called (eg was it add or divide?), I don't see an obvious way to do that. I *think* this accomplishes that?