### PR TITLE
extract method names for parent classes

### DIFF
--- a/src/getPointcutMethods.ts
+++ b/src/getPointcutMethods.ts
@@ -1,10 +1,21 @@
 export function getPointcutMethods(target: any, pointcut: string): string[] {
-    const classFunctions = Object.getOwnPropertyNames(Object.getPrototypeOf(target))
-        .filter(item => typeof target[item] === 'function' && item !== 'constructor')
-        .filter(item => item.match(pointcut));
-    const objectFunctions = Object.getOwnPropertyNames(target)
-        .filter(item => typeof target[item] === 'function' && item !== 'constructor')
-        .filter(item => item.match(pointcut));
+    const unique_method_names = new Set<string>();
 
-    return [...new Set([...classFunctions, ...objectFunctions]).values()];
+    let current_target = target;
+    while (current_target !== null && current_target !== undefined) {
+        const next_target = Object.getPrototypeOf(current_target);
+        if (next_target === null || next_target === undefined) {
+            break;
+        }
+        Object.getOwnPropertyNames(current_target)
+            .filter(item => typeof current_target[item] === 'function' && item !== 'constructor')
+            .filter(item => item.match(pointcut))
+            .forEach(item => {
+                unique_method_names.add(item);
+            });
+
+        current_target = next_target;
+    }
+
+    return [...unique_method_names.values()];
 }

--- a/test/getPointcutMethods.test.ts
+++ b/test/getPointcutMethods.test.ts
@@ -1,5 +1,5 @@
 import { getPointcutMethods } from '../src/getPointcutMethods';
-import { CalculatorCls } from './samples/CalculatorCls.sample';
+import { CalculatorCls, AdvancedCalculatorCls } from './samples/CalculatorCls.sample';
 import { CalculatorObj } from './samples/CalculatorObj.sample';
 
 describe('getPointcutMethods', () => {
@@ -10,22 +10,7 @@ describe('getPointcutMethods', () => {
     it('returns list of all methods from object for pointcut ".*" without constructor', () => {
         const methods = getPointcutMethods(CalculatorObj, '.*');
 
-        expect(methods).toStrictEqual([
-            '__defineGetter__',
-            '__defineSetter__',
-            'hasOwnProperty',
-            '__lookupGetter__',
-            '__lookupSetter__',
-            'isPrototypeOf',
-            'propertyIsEnumerable',
-            'toString',
-            'valueOf',
-            'toLocaleString',
-            'add',
-            'subtract',
-            'multiply',
-            'divide',
-        ]);
+        expect(methods).toStrictEqual(['add', 'subtract', 'multiply', 'divide']);
     });
 
     it('returns list of all methods from class instance for pointcut ".*" without constructor', () => {
@@ -42,5 +27,13 @@ describe('getPointcutMethods', () => {
         const methods = getPointcutMethods(calculator, 'add');
 
         expect(methods).toStrictEqual(['add']);
+    });
+
+    it('returns list of methods from child class instance for pointcut ".*" including inherited methods', () => {
+        const calculator = new AdvancedCalculatorCls();
+
+        const methods = getPointcutMethods(calculator, '.*');
+
+        expect(methods).toStrictEqual(['sum', 'add', 'subtract', 'multiply', 'divide']);
     });
 });

--- a/test/samples/CalculatorCls.sample.ts
+++ b/test/samples/CalculatorCls.sample.ts
@@ -18,3 +18,9 @@ export class CalculatorCls {
         return a / b;
     }
 }
+
+export class AdvancedCalculatorCls extends CalculatorCls {
+    sum(arr: number[]): number {
+        return arr.reduce((acc, val) => acc + val, 0);
+    }
+}


### PR DESCRIPTION
This PR attempts to fix issue #12 by iterating over all parent classes and extracting the method names from those as well in `getPointcutMethods`. 